### PR TITLE
DEV-1241 id to hex format

### DIFF
--- a/app/helpers/xml_helper.py
+++ b/app/helpers/xml_helper.py
@@ -16,7 +16,7 @@ def construct_request(event: SubtitleEvent) -> str:
     """ Constructs the makeSubtitleAvailableRequest XML. """
     root = etree.Element(f"{{{NAMESPACE_TNS}}}makeSubtitleAvailableRequest", nsmap=NSMAP)
     etree.SubElement(root, f"{{{NAMESPACE_TNS}}}requestor").text = f"{REQUESTOR}"
-    etree.SubElement(root, f"{{{NAMESPACE_TNS}}}correlationId").text = str(uuid4())
+    etree.SubElement(root, f"{{{NAMESPACE_TNS}}}correlationId").text = uuid4().hex
     etree.SubElement(root, f"{{{NAMESPACE_TNS}}}id").text = f"{event.media_id}"
     etree.SubElement(root, f"{{{NAMESPACE_TNS}}}destinationPath").text = (
         f"mam-collaterals/{event.destination_path_type()}/{event.media_id}"

--- a/tests/helpers/test_xml_helper.py
+++ b/tests/helpers/test_xml_helper.py
@@ -5,6 +5,8 @@ from io import BytesIO
 
 from lxml import etree
 
+from uuid import UUID
+
 from app.helpers.events_parser import SubtitleEvent
 from app.helpers.xml_helper import construct_request, NSMAP
 from tests.resources.resources import construct_filename, load_resource
@@ -17,7 +19,7 @@ def test_construct_request_open():
     xml = etree.parse(BytesIO(construct_request(event)))
     # Assert correct values in the XML
     assert _xml_value(xml, "/tns:requestor") == "VIAA"
-    assert len(_xml_value(xml, "/tns:correlationId")) == 36
+    assert UUID(_xml_value(xml, "/tns:correlationId")).version == 4
     assert _xml_value(xml, "/tns:id") == "media_id_open"
     assert _xml_value(xml, "/tns:otType") == "OPEN"
     assert _xml_value(xml, "/tns:destinationPath") == (
@@ -33,7 +35,7 @@ def test_construct_request_closed():
     xml = etree.parse(BytesIO(construct_request(event)))
     # Assert correct values in the XML
     assert _xml_value(xml, "/tns:requestor") == "VIAA"
-    assert len(_xml_value(xml, "/tns:correlationId")) == 36
+    assert UUID(_xml_value(xml, "/tns:correlationId")).version == 4
     assert _xml_value(xml, "/tns:id") == "media_id_closed"
     assert _xml_value(xml, "/tns:otType") == "CLOSED"
     assert _xml_value(xml, "/tns:destinationPath") == (


### PR DESCRIPTION
Changed Correlation ID UUID from a representation like:
`cd3302a8-cf4d-45bf-be79-8f4f86f86eb0`
to a representation like 
`eebf2d05c1504d67a8c248707d41f444`

Test for valid UUID failed because it only checked for length in characters. So that test was replaced by a check for the version of the UUID. If correlation ID is not a UUID, this gives helpful error message like `ValueError: badly formed hexadecimal UUID string`